### PR TITLE
🎨 Design: 메인페이지 explain 섹션 label 모션 수정

### DIFF
--- a/src/components/animation/LabelAnimation.jsx
+++ b/src/components/animation/LabelAnimation.jsx
@@ -1,85 +1,53 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
-import {
-  // eslint-disable-next-line no-unused-vars
-  motion,
-  useAnimationFrame,
-  useMotionValue,
-  useScroll,
-  useSpring,
-  useTransform,
-  useVelocity,
-} from 'framer-motion';
+/* eslint-disable no-unused-vars */
+import { motion, useScroll, useSpring, useTransform } from 'framer-motion';
 
-function LabelAnimation({ children, direction = 'right', maxOffset = 200, startX = 0 }) {
-  const containerRef = useRef(null);
-  const baseX = useMotionValue(0);
-  const { scrollY } = useScroll();
-  const scrollVelocity = useVelocity(scrollY);
-  const smoothVelocity = useSpring(scrollVelocity, {
-    damping: 50,
-    stiffness: 400,
-  });
-  const velocityFactor = useTransform(smoothVelocity, [0, 1000], [0, 5], {
-    clamp: false,
-  });
+/**
+ * LabelAnimation (progress-based)
+ * - 누적(baseX) 방식 제거
+ * - target 요소의 스크롤 progress(0~1)를 x로 직접 매핑
+ * - 화면 밖/진입 전/진입 후에도 항상 일관되게 동작
+ *
+ * props
+ * - direction: 'right' | 'left'
+ * - maxOffset: px 단위 (±maxOffset 범위)
+ * - startX: px 단위 정적 오프셋 (왼쪽으로 보내려면 음수)
+ * - stiffness/damping: 움직임 부드러움
+ */
+function LabelAnimation({
+  children,
+  direction = 'right',
+  maxOffset = 200,
+  startX = 0,
+  stiffness = 120,
+  damping = 24,
+}) {
+  const targetRef = useRef(null);
 
-  const directionFactor = useRef(1);
-  const baseVelocity = 80; // 기본 속도 증가
-
-  // 컴포넌트 마운트 시 baseX를 항상 0으로 리셋
-  useEffect(() => {
-    baseX.set(0);
-  }, [baseX]);
-
-  useAnimationFrame((t, delta) => {
-    const scrollSpeed = Math.abs(velocityFactor.get());
-
-    // 스크롤 속도가 거의 0이면 움직이지 않음
-    if (scrollSpeed < 0.01) {
-      return;
-    }
-
-    // 스크롤 방향에 따라 directionFactor 설정
-    if (velocityFactor.get() < 0) {
-      directionFactor.current = -1;
-    } else if (velocityFactor.get() > 0) {
-      directionFactor.current = 1;
-    }
-
-    // direction에 따라 이동 방향 결정
-    // 'right': 스크롤 내릴 때 오른쪽(양수), 올릴 때 왼쪽(음수)
-    // 'left': 스크롤 내릴 때 왼쪽(음수), 올릴 때 오른쪽(양수)
-    let velocityMultiplier = direction === 'right' ? 1 : -1;
-
-    // 스크롤 속도에만 비례하여 움직임 (속도 배율 증가로 더 역동적으로)
-    let moveBy =
-      directionFactor.current *
-      baseVelocity *
-      velocityMultiplier *
-      (delta / 1000) *
-      scrollSpeed *
-      0.3;
-
-    // 현재 위치(0)에서 시작, 최대 이동 거리 제한
-    const newX = baseX.get() + moveBy;
-    const clampedX = Math.max(-maxOffset, Math.min(maxOffset, newX));
-
-    baseX.set(clampedX);
+  // targetRef가 뷰포트에서 지나가는 정도를 0~1로 잡음
+  // "start end" = target의 시작이 viewport 끝에 닿을 때 0
+  // "end start" = target의 끝이 viewport 시작에 닿을 때 1
+  const { scrollYProgress } = useScroll({
+    target: targetRef,
+    offset: ['start end', 'end start'],
   });
 
-  // 정적 오프셋(startX) + 스크롤 반응(baseX)
-  const x = useTransform(baseX, (v) => v + startX);
+  // progress를 스프링 처리해서 부드럽게
+  const smooth = useSpring(scrollYProgress, { stiffness, damping });
+
+  // 0~1을 -1~1로 펼쳐서 중앙(0.5)에서 0 되게
+  const centered = useTransform(smooth, (v) => (v - 0.5) * 2);
+
+  // 방향 적용
+  const dir = direction === 'right' ? 1 : -1;
+
+  // x를 progress 기반으로 "직접" 계산 (누적 없음)
+  const x = useTransform(centered, (v) => startX + dir * v * maxOffset);
 
   return (
-    <div ref={containerRef}>
-      <motion.div
-        style={{
-          x: x,
-        }}
-      >
-        {children}
-      </motion.div>
+    <div ref={targetRef}>
+      <motion.div style={{ x }}>{children}</motion.div>
     </div>
   );
 }

--- a/src/components/main/explain/Explain.jsx
+++ b/src/components/main/explain/Explain.jsx
@@ -122,7 +122,7 @@ function Explain() {
         >
           {/* Label BLAH 1 */}
           <div className="flex justify-start mb-3" style={{ transform: 'translateY(-40%)' }}>
-            <LabelAnimation direction="right" maxOffset={300}>
+            <LabelAnimation direction="right" maxOffset={150} startX={150}>
               <img
                 src={labelBlah1Icon}
                 alt="Label BLAH 1"
@@ -132,7 +132,7 @@ function Explain() {
                   height: `${(140 / 16) * scale}rem`,
                   minWidth: `${(1220 / 16) * scale}rem`,
                   minHeight: `${(140 / 16) * scale}rem`,
-                  marginLeft: `${(400 / 16) * scale}rem`,
+                  marginLeft: `${(100 / 16) * scale}rem`,
                   imageRendering: 'crisp-edges',
                   display: 'block',
                 }}
@@ -142,7 +142,7 @@ function Explain() {
 
           {/* Label BLAH 2 */}
           <div className="flex justify-end mb-[-15px]" style={{ transform: 'translateY(-30%)' }}>
-            <LabelAnimation direction="left" maxOffset={500}>
+            <LabelAnimation direction="left" maxOffset={150} startX={-150}>
               <img
                 src={labelBlah2Icon}
                 alt="Label BLAH 2"
@@ -152,7 +152,7 @@ function Explain() {
                   height: `${(140 / 16) * scale}rem`,
                   minWidth: `${(1220 / 16) * scale}rem`,
                   minHeight: `${(140 / 16) * scale}rem`,
-                  marginRight: `${(500 / 16) * scale}rem`,
+                  marginRight: `${(100 / 16) * scale}rem`,
                   imageRendering: 'crisp-edges',
                   display: 'block',
                 }}


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #50 

## 📝 요약(Summary)

스크롤 속도가 아니라 스크롤 위치(progress)로 이미지 위치를 직접 계산하도록 구조를 바꿈
scrollYProgress → x를 순수 함수로 매핑해서, 화면 밖, 진입 전, 아래→위 스크롤에서도 항상 즉시 반응
startX(정적 위치)와 maxOffset(이동 범위)를 분리해 멈춤 제거

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="1852" height="1004" alt="image" src="https://github.com/user-attachments/assets/b3343905-bd86-4d6f-8d22-f424f6b7f339" />

## 💬 공유사항 to 리뷰어
모션 이상한 부분 있으면 공유해주세요!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
