### PR TITLE
✨ Feat: proxy 설정 및 비밀번호 변경 api 연동

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,26 +1,59 @@
 import axios from 'axios';
 
-const BASE_URL = import.meta.env.VITE_SERVER_BASE_URL;
+import { refresh } from '@/api/authApi';
+import useAuthStore from '@/store/useAuthStore';
 
 // 공용 API 인스턴스 (토큰이 필요 없는 경우)
 const publicAPI = axios.create({
-  baseURL: BASE_URL,
+  baseURL: '/api', // 중요: 환경변수 BASE_URL 쓰지 말기
 });
 
-// 인증 API 인스턴스 (토큰이 필요한 경우)
+// 인증 API 인스턴스 (쿠키 기반 인증)
 const privateAPI = axios.create({
-  baseURL: BASE_URL,
-  withCredentials: false,
+  baseURL: '/api', // 중요: 환경변수 BASE_URL 쓰지 말기
+  withCredentials: true, // 쿠키 전송 활성화
 });
 
-// accessToken을 자동으로 Authorization 헤더에 삽입
-privateAPI.interceptors.request.use((config) => {
-  const token = localStorage.getItem('accessToken');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+// 쿠키 기반 인증이므로 Authorization 헤더 삽입 불필요
+// 쿠키가 자동으로 전송됨
+
+// refresh 중복 호출 방지
+let isRefreshing = false;
+
+// 응답 인터셉터: 401 에러 시 자동 refresh + 재시도
+privateAPI.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 에러이고, 아직 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // 이미 refresh 중이면 원래 요청 실패 처리
+      if (isRefreshing) {
+        return Promise.reject(error);
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        // refresh API 호출
+        await refresh();
+        // refresh 성공 시 원래 요청 1번만 재시도
+        isRefreshing = false;
+        return privateAPI(originalRequest);
+      } catch (refreshError) {
+        // refresh 실패 (401/403) 시 상태 초기화하고 alert 표시
+        isRefreshing = false;
+        useAuthStore.getState().logout();
+        alert('401입니다.');
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
   }
-  return config;
-});
+);
 
 /**
  * API 서비스 객체

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -2,11 +2,9 @@ import axios from 'axios';
 
 import { publicAPI } from '@/api/api';
 
-const BASE_URL = import.meta.env.VITE_SERVER_BASE_URL;
-
 // auth 전용 (쿠키 포함)
 const authAPI = axios.create({
-  baseURL: BASE_URL,
+  baseURL: '/api', // 중요: 환경변수 BASE_URL 쓰지 말기
   withCredentials: true,
 });
 

--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -1,7 +1,17 @@
-import { APIService } from '@/api/api';
+import { privateAPI } from '@/api/api';
 
 export const getClubMember = () => {
   // try{
   //     const res=APIService.public.get()
   // }
 };
+
+// 비밀번호 변경
+export const changePassword = ({ currentPassword, newPassword, newPasswordConfirmation }) =>
+  privateAPI
+    .patch('/v1/users/me/password', {
+      currentPassword,
+      newPassword,
+      newPasswordConfirmation,
+    })
+    .then((r) => r.data);

--- a/src/pages/MyPage/PasswordChange.jsx
+++ b/src/pages/MyPage/PasswordChange.jsx
@@ -1,19 +1,19 @@
+import { changePassword } from '@/api/userApi';
 import PasswordChangeForm from '@/components/mypage/PasswordChangeForm';
 
 export default function PasswordChange() {
   const handlePasswordChange = async (credentials) => {
     try {
-      // TODO: 실제 비밀번호 변경 API 호출
-      // 엔드포인트 예: api/v1/auth/password/change
-      // await APIService.private.put('api/v1/auth/password/change', {
-      //   currentPassword: credentials.currentPassword,
-      //   newPassword: credentials.newPassword,
-      // });
-      console.log('Password change attempt:', credentials);
+      await changePassword({
+        currentPassword: credentials.currentPassword,
+        newPassword: credentials.newPassword,
+        newPasswordConfirmation: credentials.confirmPassword,
+      });
       // 비밀번호 변경 성공 시 마이페이지로 이동 (PasswordChangeForm에서 처리)
     } catch (error) {
       console.error('비밀번호 변경 실패:', error);
       // TODO: 에러 처리 (토스트 메시지 등)
+      throw error; // PasswordChangeForm에서 에러 처리할 수 있도록 throw
     }
   };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,4 +12,20 @@ export default defineConfig({
   resolve: {
     alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
   },
+  server: {
+    proxy: {
+      // 프론트는 /api 로만 호출하고, 실제는 dev 서버로 프록시
+      '/api': {
+        target: 'https://dev.skulikelion.site',
+        changeOrigin: true,
+        secure: true, // https 대상이므로 true
+        // 필요하면 경로 그대로 유지 (지금 dev가 /api/... 쓰니까 rewrite 불필요)
+        // rewrite: (path) => path.replace(/^\/api/, '/api'),
+
+        // 쿠키 도메인/패스가 문제면 아래처럼 리라이트(선택)
+        // cookieDomainRewrite: 'localhost',
+        // cookiePathRewrite: '/',
+      },
+    },
+  },
 });


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #221 

## 📝 요약(Summary)

- 프론트 proxy 설정
- 프록시 사용 중이므로 API baseURL은 /api로 고정
- /v1/auth/** 는 무조건 authAPI 사용
- axios 직접 사용X
- 비밀번호 변경 api 연동

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="756" height="590" alt="image" src="https://github.com/user-attachments/assets/31f15d2a-4720-423d-8ccd-b03e9bf8982b" />

## 💬 공유사항 to 리뷰어
pull 받고 나서 npm i 해주시구
axios 인스턴스는 새로 만들 필요 없습니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
